### PR TITLE
Endomondo now receives non-gps activities just fine

### DIFF
--- a/tapiriik/services/Endomondo/endomondo.py
+++ b/tapiriik/services/Endomondo/endomondo.py
@@ -93,7 +93,7 @@ class EndomondoService(ServiceBase):
 
     SupportedActivities = list(_activityMappings.values())
 
-    ReceivesNonGPSActivitiesWithOtherSensorData = False
+    ReceivesNonGPSActivitiesWithOtherSensorData = True
 
     def WebInit(self):
         self.UserAuthorizationURL = reverse("oauth_redirect", kwargs={"service": "endomondo"})


### PR DESCRIPTION
It used to be true that Endomondo was dependent on GPS data but this was a long time ago.